### PR TITLE
fix: change usage text to reflect new binary name

### DIFF
--- a/cmd/blox_init.go
+++ b/cmd/blox_init.go
@@ -19,7 +19,7 @@ var (
 // initCmd represents the init command
 var initCmd = &cobra.Command{
 	Use:   "init",
-	Short: "Create folders and configuration to maintain content with the drb toolset",
+	Short: "Create folders and configuration to maintain content with the blox toolset",
 	Long: `Create a group of folders to store your content. 
 
 If provided, the folders will be created under the "base" directory. 
@@ -29,7 +29,7 @@ folders will be created in the root of the current directory.
 The "source" directory will store your un-processed content, 
 typically Markdown files.
 
-The "destination" directory is where the drb tools will put 
+The "destination" directory is where the blox tools will put 
 content after it has been validated and processed.
 
 The "template" directory is where you can store templates for

--- a/cmd/blox_new.go
+++ b/cmd/blox_new.go
@@ -43,5 +43,5 @@ package cmd
 
 // 	newCmd.Flags().StringVarP(&model, "type", "t", "article", "type of content to create")
 // 	cobra.CheckErr(newCmd.MarkFlagRequired("type"))
-// 	newCmd.SetUsageTemplate("drb new --type [type name] [slug]")
+// 	newCmd.SetUsageTemplate("blox new --type [type name] [slug]")
 // }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -49,7 +49,7 @@ func init() {
 	// Cobra supports persistent flags, which, if defined here,
 	// will be global for your application.
 
-	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.drb.yaml)")
+	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.blox.yaml)")
 
 	rootCmd.PersistentFlags().BoolVar(&quiet, "quiet", false, "disable logging")
 
@@ -65,9 +65,9 @@ func initConfig() {
 		home, err := homedir.Dir()
 		cobra.CheckErr(err)
 
-		// Search config in home directory with name ".drb" (without extension).
+		// Search config in home directory with name ".blox" (without extension).
 		viper.AddConfigPath(home)
-		viper.SetConfigName(".drb")
+		viper.SetConfigName(".blox")
 	}
 
 	viper.AutomaticEnv() // read in environment variables that match


### PR DESCRIPTION
Updates command usage text from `drb` to `blox`