### PR TITLE
Add Remote Schemas to config file

### DIFF
--- a/blox.cue
+++ b/blox.cue
@@ -1,4 +1,10 @@
 {
+    #Remote: {
+        name: string
+        version: string
+        repository: string
+    }
     data_dir: "dogfood/data"
     schemata_dir: "dogfood/schemata"
+    remotes: [...#Remote]
 }

--- a/blox.cue
+++ b/blox.cue
@@ -1,10 +1,4 @@
 {
-    #Remote: {
-        name: string
-        version: string
-        repository: string
-    }
     data_dir: "dogfood/data"
     schemata_dir: "dogfood/schemata"
-    remotes: [...#Remote]
 }

--- a/config.go
+++ b/config.go
@@ -1,6 +1,7 @@
 package blox
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 
@@ -63,6 +64,21 @@ func (r *Config) GetString(key string) (string, error) {
 	}
 
 	return "", fmt.Errorf("couldn't find key '%s'", key)
+}
+
+func (r *Config) GetList(key string) (cue.Value, error) {
+
+	keyValue := r.runtime.Database.LookupPath(cue.ParsePath(key))
+
+	if keyValue.Exists() {
+		_, err := keyValue.List()
+		if err != nil {
+			return cue.Value{}, err
+		}
+
+		return keyValue, nil
+	}
+	return cue.Value{}, errors.New("not found")
 }
 
 func (r *Config) GetStringOr(key string, def string) string {


### PR DESCRIPTION
Adds remote schema block to config file.
`blox build` ensures that remote schemas exist locally before building.