### PR TITLE
feat: add plugins

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,7 +3,10 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path"
+	"path/filepath"
 
+	"github.com/arrase/cobraplugins"
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 
@@ -42,6 +45,7 @@ func Execute() {
 func init() {
 	cobra.OnInitialize(initConfig)
 
+	loadPlugins(rootCmd)
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.blox.yaml)")
 	rootCmd.PersistentFlags().BoolVar(&quiet, "quiet", false, "disable logging")
 	rootCmd.PersistentFlags().BoolVar(&debug, "debug", false, "enable debug logging, overrides 'quiet' flag")
@@ -68,4 +72,25 @@ func initConfig() {
 	if err := viper.ReadInConfig(); err == nil {
 		fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
 	}
+}
+
+func loadPlugins(cmd *cobra.Command) {
+	pterm.Info.Println("Searching for plugins")
+	home, err := homedir.Dir()
+	cobra.CheckErr(err)
+	pluginPath := path.Join(home, ".blox", "plugins")
+	err = filepath.Walk(pluginPath,
+		func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if !info.IsDir() {
+
+				pterm.Info.Printf("\tloading %s\n", path)
+				cmd.AddCommand(cobraplugins.GetCmd(path, "MainCmd"))
+			}
+
+			return nil
+		})
+	cobra.CheckErr(err)
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	cuelang.org/go v0.3.0
+	github.com/arrase/cobraplugins v0.0.0-20200712113530-7d44df38707e // indirect
 	github.com/goccy/go-yaml v1.8.9
 	github.com/google/go-cmp v0.5.5 // indirect
 	github.com/hashicorp/go-multierror v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,8 @@ github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da h1:8GUt8eRujhVEGZ
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310 h1:BUAU3CGlLvorLI26FmByPp2eC2qla6E1Tw+scpcg/to=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
+github.com/arrase/cobraplugins v0.0.0-20200712113530-7d44df38707e h1:X2diQc4kSNupubVYt9yvBGNKIkh0or+SZFLu/gXm3a4=
+github.com/arrase/cobraplugins v0.0.0-20200712113530-7d44df38707e/go.mod h1:pq1rGuIPLPZiob17NEKvvkfJKEWTADdt6vdNi7Y4IT0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0 h1:HWo1m869IqiPhD389kmkxeTalrjNbbJTC8LXupb+sl0=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=


### PR DESCRIPTION
search for compatible plugins in $HOME/.blox/plugins

Plugins must be compiled with the same versions of cobra libraries or they won't load.