### PR TITLE
bug: fix error handling when static and image directories don't exist

### DIFF
--- a/internal/cmd/blox_build.go
+++ b/internal/cmd/blox_build.go
@@ -285,15 +285,28 @@ func processImages(cfg *blox.Config) error {
 	staticDir, err := cfg.GetString("static_dir")
 	if err != nil {
 		pterm.Info.Printf("no static directory present, skipping image linking")
+		return nil
 	}
-	cobra.CheckErr(err)
+
 	pterm.Info.Printf("processing images in %s\n", staticDir)
 	fi, err := os.Stat(staticDir)
-	cobra.CheckErr(err)
+	if errors.Is(err, os.ErrNotExist) {
+		pterm.Info.Println("no image directory found, skipping")
+		return nil
+	}
 	if !fi.IsDir() {
 		return errors.New("given static directory is not a directory")
 	}
 	imagesDirectory := filepath.Join(staticDir, "images")
+
+	fi, err = os.Stat(imagesDirectory)
+	if errors.Is(err, os.ErrNotExist) {
+		pterm.Info.Println("no image directory found, skipping")
+		return nil
+	}
+	if !fi.IsDir() {
+		return errors.New("given images directory is not a directory")
+	}
 	err = filepath.Walk(imagesDirectory,
 		func(path string, info os.FileInfo, err error) error {
 			if err != nil {


### PR DESCRIPTION
when there is no static_dir entry in blox.cue, there was an error
when static_dir specified doesn't exist, there was an error
when images directory doesn't exist, there was an error

handled these with graceful messages.