### PR TITLE
fix: use dataset plural metadata for all queries

### DIFF
--- a/content/graphql.go
+++ b/content/graphql.go
@@ -148,7 +148,7 @@ func (s *Service) translateNode(node interface{}, graphqlObjects map[string]cued
 		Resolve: resolver,
 	}
 
-	graphqlFields[fmt.Sprintf("all%vs", dataSet.GetExternalName())] = &graphql.Field{
+	graphqlFields[fmt.Sprintf("all%v", dataSet.GetPluralName())] = &graphql.Field{
 		Type: graphql.NewList(objType),
 		Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 			dataSetName := p.Info.ReturnType.Name()

--- a/content/graphql.go
+++ b/content/graphql.go
@@ -91,7 +91,7 @@ func (s *Service) translateNode(node interface{}, graphqlObjects map[string]cued
 	dataSet, _ := s.engine.GetDataSet(node.(*cuedb.DagNode).Name)
 
 	var objectFields graphql.Fields
-	objectFields, err := cuedb.CueValueToGraphQlField(graphqlObjects, dataSet.GetSchemaCue())
+	objectFields, err := cuedb.CueValueToGraphQlField(graphqlObjects, dataSet, dataSet.GetSchemaCue())
 	if err != nil {
 		cobra.CheckErr(err)
 	}

--- a/internal/cuedb/dataset.go
+++ b/internal/cuedb/dataset.go
@@ -52,6 +52,10 @@ func (d *DataSet) GetDataMapCue() string {
 	)
 }
 
+func (d *DataSet) GetPluralName() string {
+	return strings.Title(d.metadata.Plural)
+}
+
 func (d *DataSet) GetExternalName() string {
 	return strings.Replace(d.name, "#", "", 1)
 }

--- a/internal/cuedb/graphql_test.go
+++ b/internal/cuedb/graphql_test.go
@@ -11,66 +11,89 @@ import (
 func TestGraphqlGeneration(t *testing.T) {
 	type test struct {
 		cueLiteral string
+		dataSet    *DataSet
 		expected   graphql.Fields
 	}
 
 	tests := []test{
-		{cueLiteral: "t1: string", expected: graphql.Fields{
-			"t1": {Type: &graphql.NonNull{OfType: graphql.String}},
-		}},
-		{cueLiteral: "t2: int", expected: graphql.Fields{
-			"t2": {Type: &graphql.NonNull{OfType: graphql.Int}},
-		}},
-		{cueLiteral: "t3: [...int]", expected: graphql.Fields{
-			"t3": {Type: &graphql.List{OfType: graphql.Int}},
-		}},
-		{cueLiteral: "t4: [...string]", expected: graphql.Fields{
-			"t4": {Type: &graphql.List{OfType: graphql.String}},
-		}},
-		{cueLiteral: "t5: string, t6?: int", expected: graphql.Fields{
-			"t5": {Type: &graphql.NonNull{OfType: graphql.String}},
-			"t6": {Type: graphql.Int},
-		}},
-		{cueLiteral: "{ t7: string, t8: { t9: string, t10: string} }", expected: graphql.Fields{
-			"t7": {Type: &graphql.NonNull{OfType: graphql.String}},
-			"t8": {Type: graphql.NewObject(graphql.ObjectConfig{
-				Fields: graphql.Fields{
-					"t9":  {Type: &graphql.NonNull{OfType: graphql.String}},
-					"t10": {Type: &graphql.NonNull{OfType: graphql.String}},
-				},
-			})},
-		}},
-		{cueLiteral: "{ t11: string, t12: { t13: string, t14: string, t15: { t16: int } } }", expected: graphql.Fields{
-			"t11": {Type: &graphql.NonNull{OfType: graphql.String}},
-			"t12": {Type: graphql.NewObject(graphql.ObjectConfig{
-				Fields: graphql.Fields{
-					"t13": {Type: &graphql.NonNull{OfType: graphql.String}},
-					"t14": {Type: &graphql.NonNull{OfType: graphql.String}},
-					"t15": {Type: graphql.NewObject(graphql.ObjectConfig{
-						Fields: graphql.Fields{
-							"t16": {Type: &graphql.NonNull{OfType: graphql.Int}},
-						},
-					})},
-				},
-			})},
-		}},
-		{cueLiteral: "{ #Test: { t19: string}\nt17: string, t18: #Test }", expected: graphql.Fields{
-			"t17": {Type: &graphql.NonNull{OfType: graphql.String}},
-			"t18": {Type: graphql.NewObject(graphql.ObjectConfig{
-				Fields: graphql.Fields{
-					"t19": {Type: &graphql.NonNull{OfType: graphql.String}},
-				},
-			})},
-		}},
-		{cueLiteral: "{ #Test: { t20: string}\n t21: string, t22: [ ... #Test ] }", expected: graphql.Fields{
-			"t21": {Type: &graphql.NonNull{OfType: graphql.String}},
-			"t22": {Type: &graphql.List{OfType: graphql.NewObject(graphql.ObjectConfig{
-				Name: "t22",
-				Fields: graphql.Fields{
-					"t20": {Type: &graphql.NonNull{OfType: graphql.String}},
-				},
-			})}},
-		}},
+		{
+			dataSet:    &DataSet{name: "Type"},
+			cueLiteral: "t1: string", expected: graphql.Fields{
+				"t1": {Type: &graphql.NonNull{OfType: graphql.String}},
+			}},
+		{
+			dataSet:    &DataSet{name: "Type"},
+			cueLiteral: "t2: int", expected: graphql.Fields{
+				"t2": {Type: &graphql.NonNull{OfType: graphql.Int}},
+			}},
+		{
+			dataSet:    &DataSet{name: "Type"},
+			cueLiteral: "t3: [...int]", expected: graphql.Fields{
+				"t3": {Type: &graphql.List{OfType: graphql.Int}},
+			}},
+		{
+			dataSet:    &DataSet{name: "Type"},
+			cueLiteral: "t4: [...string]", expected: graphql.Fields{
+				"t4": {Type: &graphql.List{OfType: graphql.String}},
+			}},
+		{
+			dataSet:    &DataSet{name: "Type"},
+			cueLiteral: "t5: string, t6?: int", expected: graphql.Fields{
+				"t5": {Type: &graphql.NonNull{OfType: graphql.String}},
+				"t6": {Type: graphql.Int},
+			}},
+		{
+			dataSet:    &DataSet{name: "Type"},
+			cueLiteral: "{ t7: string, t8: { t9: string, t10: string} }", expected: graphql.Fields{
+				"t7": {Type: &graphql.NonNull{OfType: graphql.String}},
+				"t8": {Type: graphql.NewObject(graphql.ObjectConfig{
+					Name: "TypeT8",
+					Fields: graphql.Fields{
+						"t9":  {Type: &graphql.NonNull{OfType: graphql.String}},
+						"t10": {Type: &graphql.NonNull{OfType: graphql.String}},
+					},
+				})},
+			}},
+		{
+			dataSet:    &DataSet{name: "Type"},
+			cueLiteral: "{ t11: string, t12: { t13: string, t14: string, t15: { t16: int } } }", expected: graphql.Fields{
+				"t11": {Type: &graphql.NonNull{OfType: graphql.String}},
+				"t12": {Type: graphql.NewObject(graphql.ObjectConfig{
+					Name: "TypeT12",
+					Fields: graphql.Fields{
+						"t13": {Type: &graphql.NonNull{OfType: graphql.String}},
+						"t14": {Type: &graphql.NonNull{OfType: graphql.String}},
+						"t15": {Type: graphql.NewObject(graphql.ObjectConfig{
+							Name: "TypeT15",
+							Fields: graphql.Fields{
+								"t16": {Type: &graphql.NonNull{OfType: graphql.Int}},
+							},
+						})},
+					},
+				})},
+			}},
+		{
+			dataSet:    &DataSet{name: "Type"},
+			cueLiteral: "{ #Test: { t19: string}\nt17: string, t18: #Test }", expected: graphql.Fields{
+				"t17": {Type: &graphql.NonNull{OfType: graphql.String}},
+				"t18": {Type: graphql.NewObject(graphql.ObjectConfig{
+					Name: "TypeT18",
+					Fields: graphql.Fields{
+						"t19": {Type: &graphql.NonNull{OfType: graphql.String}},
+					},
+				})},
+			}},
+		{
+			dataSet:    &DataSet{name: "Type"},
+			cueLiteral: "{ #Test: { t20: string}\n t21: string, t22: [ ... #Test ] }", expected: graphql.Fields{
+				"t21": {Type: &graphql.NonNull{OfType: graphql.String}},
+				"t22": {Type: &graphql.List{OfType: graphql.NewObject(graphql.ObjectConfig{
+					Name: "TypeT22",
+					Fields: graphql.Fields{
+						"t20": {Type: &graphql.NonNull{OfType: graphql.String}},
+					},
+				})}},
+			}},
 		// WIP
 		// Aim is to "flatten" disjunctions into a single struct
 		// {cueLiteral: "{ #A: {t23: string}\n#B: { t24?: string}\n t25: string, t26: [ ... #A | #B ] }", expected: graphql.Fields{
@@ -92,7 +115,7 @@ func TestGraphqlGeneration(t *testing.T) {
 
 		graphqlObjects := make(map[string]GraphQlObjectGlue)
 
-		graphQlObject, err := CueValueToGraphQlField(graphqlObjects, cueValue)
+		graphQlObject, err := CueValueToGraphQlField(graphqlObjects, *tc.dataSet, cueValue)
 		assert.Equal(t, nil, err)
 		assert.EqualValues(t, tc.expected, graphQlObject)
 	}

--- a/internal/cuedb/graphql_test.go
+++ b/internal/cuedb/graphql_test.go
@@ -20,28 +20,33 @@ func TestGraphqlGeneration(t *testing.T) {
 			dataSet:    &DataSet{name: "Type"},
 			cueLiteral: "t1: string", expected: graphql.Fields{
 				"t1": {Type: &graphql.NonNull{OfType: graphql.String}},
-			}},
+			},
+		},
 		{
 			dataSet:    &DataSet{name: "Type"},
 			cueLiteral: "t2: int", expected: graphql.Fields{
 				"t2": {Type: &graphql.NonNull{OfType: graphql.Int}},
-			}},
+			},
+		},
 		{
 			dataSet:    &DataSet{name: "Type"},
 			cueLiteral: "t3: [...int]", expected: graphql.Fields{
 				"t3": {Type: &graphql.List{OfType: graphql.Int}},
-			}},
+			},
+		},
 		{
 			dataSet:    &DataSet{name: "Type"},
 			cueLiteral: "t4: [...string]", expected: graphql.Fields{
 				"t4": {Type: &graphql.List{OfType: graphql.String}},
-			}},
+			},
+		},
 		{
 			dataSet:    &DataSet{name: "Type"},
 			cueLiteral: "t5: string, t6?: int", expected: graphql.Fields{
 				"t5": {Type: &graphql.NonNull{OfType: graphql.String}},
 				"t6": {Type: graphql.Int},
-			}},
+			},
+		},
 		{
 			dataSet:    &DataSet{name: "Type"},
 			cueLiteral: "{ t7: string, t8: { t9: string, t10: string} }", expected: graphql.Fields{
@@ -53,7 +58,8 @@ func TestGraphqlGeneration(t *testing.T) {
 						"t10": {Type: &graphql.NonNull{OfType: graphql.String}},
 					},
 				})},
-			}},
+			},
+		},
 		{
 			dataSet:    &DataSet{name: "Type"},
 			cueLiteral: "{ t11: string, t12: { t13: string, t14: string, t15: { t16: int } } }", expected: graphql.Fields{
@@ -71,7 +77,8 @@ func TestGraphqlGeneration(t *testing.T) {
 						})},
 					},
 				})},
-			}},
+			},
+		},
 		{
 			dataSet:    &DataSet{name: "Type"},
 			cueLiteral: "{ #Test: { t19: string}\nt17: string, t18: #Test }", expected: graphql.Fields{
@@ -82,7 +89,8 @@ func TestGraphqlGeneration(t *testing.T) {
 						"t19": {Type: &graphql.NonNull{OfType: graphql.String}},
 					},
 				})},
-			}},
+			},
+		},
 		{
 			dataSet:    &DataSet{name: "Type"},
 			cueLiteral: "{ #Test: { t20: string}\n t21: string, t22: [ ... #Test ] }", expected: graphql.Fields{
@@ -93,7 +101,8 @@ func TestGraphqlGeneration(t *testing.T) {
 						"t20": {Type: &graphql.NonNull{OfType: graphql.String}},
 					},
 				})}},
-			}},
+			},
+		},
 		// WIP
 		// Aim is to "flatten" disjunctions into a single struct
 		// {cueLiteral: "{ #A: {t23: string}\n#B: { t24?: string}\n t25: string, t26: [ ... #A | #B ] }", expected: graphql.Fields{


### PR DESCRIPTION
When the schema name is `#Person`, we were getting a GraphQL all query of `allPersons`.

We have the Plural in our metadata, so lets use it.